### PR TITLE
fix: 🐛 Fix the github token secret for releases workflow

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Release
+      - name: Create a Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
The workflow requires a special token in order to work with protected
branches, like master in this case